### PR TITLE
* Update <group.id> in pom.xml from "com.licel" to "de.ohmesoftware"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <asm.version>9.2</asm.version>
         <github.dev.host>github.com</github.dev.host>
-        <group.id>com.licel</group.id>
+        <group.id>de.ohmesoftware</group.id>
     </properties>
 
     <groupId>${group.id}</groupId>


### PR DESCRIPTION
The pull request is to fix a problem with the jcardsim metadata that breaks artifact resolution in gradle. I believe the group id in the project POM needs to be changed to match the coordinate you used when publishing to maven central. The following is the error  reported by gradle when it retrieves the artifact:

>> Could not resolve de.ohmesoftware:jcardsim:3.0.5-2.
>> inconsistent module metadata found. Descriptor: com.licel:jcardsim:3.0.5-2 Errors: bad group: expected='de.ohmesoftware' found='com.licel'